### PR TITLE
Handle errors in useUnits hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,11 @@ import type {Unit} from './data/sampleUnits';
 import { useState } from 'react';
 
 function App() {
-    const { units, loading } = useUnits();
+    const { units, loading, error } = useUnits();
     const [selectedUnit, setSelectedUnit] = useState<Unit | null>(null);
 
     if (loading) return <div>Loading...</div>;
+    if (error) return <div>Error loading units: {error.message}</div>;
     if (units.length === 0) return <div>No units available</div>;
 
     return (

--- a/src/hooks/useUnits.ts
+++ b/src/hooks/useUnits.ts
@@ -1,22 +1,29 @@
 import { useEffect, useState } from 'react';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
-import type {Unit} from '../data/sampleUnits';
+import type { Unit } from '../data/sampleUnits';
 
 export const useUnits = () => {
     const [units, setUnits] = useState<Unit[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
 
     useEffect(() => {
         const fetchUnits = async () => {
-            const querySnapshot = await getDocs(collection(db, 'units'));
-            const data = querySnapshot.docs.map(doc => doc.data() as Unit);
-            setUnits(data);
-            setLoading(false);
+            try {
+                const querySnapshot = await getDocs(collection(db, 'units'));
+                const data = querySnapshot.docs.map((doc) => doc.data() as Unit);
+                setUnits(data);
+            } catch (err) {
+                console.error('Failed to fetch units:', err);
+                setError(err as Error);
+            } finally {
+                setLoading(false);
+            }
         };
 
         fetchUnits();
     }, []);
 
-    return { units, loading };
+    return { units, loading, error };
 };


### PR DESCRIPTION
## Summary
- add error state and try/catch to `useUnits`
- surface unit load errors in `App`

## Testing
- `npm run lint` *(fails: Unexpected any in Login.tsx and Signup.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68798f1bfca88325a698a81033c5529f