### PR TITLE
Add user progress tracking system

### DIFF
--- a/src/components/ActivityEmbed.tsx
+++ b/src/components/ActivityEmbed.tsx
@@ -1,17 +1,78 @@
-import type {Activity} from '../data/sampleUnits';
+import React, { useState } from 'react';
+import { useProgress } from '../contexts/ProgressContext';
+import type { Activity } from '../data/sampleUnits';
 
-const ActivityEmbed: React.FC<{ activity: Activity }> = ({ activity }) => {
+interface ActivityEmbedProps {
+  activity: Activity;
+  unitId: number;
+  isUnlocked: boolean;
+}
+
+const ActivityEmbed: React.FC<ActivityEmbedProps> = ({ activity, unitId, isUnlocked }) => {
+  const { markActivityCompleted, getUnitProgress } = useProgress();
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  const unitProgress = getUnitProgress(unitId);
+  const isActivityCompleted = unitProgress?.activitiesCompleted.includes(activity.id) || false;
+
+  const handleActivityComplete = () => {
+    if (!isCompleted && !isActivityCompleted) {
+      setIsCompleted(true);
+      markActivityCompleted(unitId, activity.id);
+    }
+  };
+
+  if (!isUnlocked) {
     return (
-        <div style={{ marginTop: '20px' }}>
-            <iframe
-                src={activity.url}
-                width="100%"
-                height="400"
-                title={`Activity ${activity.id}`}
-                allowFullScreen
-            />
+      <div className="mt-6 p-6 bg-gray-100 rounded-lg border-2 border-dashed border-gray-300">
+        <div className="text-center">
+          <div className="text-4xl mb-2">🔒</div>
+          <h3 className="text-lg font-semibold text-gray-700 mb-2">Activity Locked</h3>
+          <p className="text-gray-600">Complete the video above to unlock this activity</p>
         </div>
+      </div>
     );
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold">Activity {activity.id}</h3>
+        {(isCompleted || isActivityCompleted) && (
+          <span className="bg-green-100 text-green-800 px-3 py-1 rounded-full text-sm font-medium">
+            ✓ Completed
+          </span>
+        )}
+      </div>
+
+      <div className="relative">
+        <iframe
+          src={activity.url}
+          width="100%"
+          height="400"
+          title={`Activity ${activity.id}`}
+          allowFullScreen
+          className="rounded-lg shadow-lg"
+          onLoad={() => {
+            setTimeout(() => {
+              handleActivityComplete();
+            }, 30000);
+          }}
+        />
+
+        {!isCompleted && !isActivityCompleted && (
+          <div className="mt-2">
+            <button
+              onClick={handleActivityComplete}
+              className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 text-sm"
+            >
+              Mark as Completed
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default ActivityEmbed;

--- a/src/components/UnitPage.tsx
+++ b/src/components/UnitPage.tsx
@@ -1,20 +1,94 @@
-import { useState } from 'react';
-import type {Unit} from '../data/sampleUnits';
+import React, { useState } from 'react';
+import { useProgress } from '../contexts/ProgressContext';
+import type { Unit } from '../data/sampleUnits';
 import VideoPlayer from './VideoPlayer';
 import ActivityEmbed from './ActivityEmbed';
 
-const UnitPage: React.FC<{ unit: Unit }> = ({ unit }) => {
-    const [videoWatched, setVideoWatched] = useState(false);
+interface UnitPageProps {
+  unit: Unit;
+}
 
-    return (
-        <div style={{ padding: '2rem' }}>
-            <h1>{unit.title}</h1>
-            <VideoPlayer url={unit.videoUrl} onWatched={() => setVideoWatched(true)} />
-            {videoWatched && unit.activities.map(a => (
-                <ActivityEmbed key={a.id} activity={a} />
-            ))}
+const UnitPage: React.FC<UnitPageProps> = ({ unit }) => {
+  const { getUnitProgress } = useProgress();
+  const [videoCompleted, setVideoCompleted] = useState(false);
+
+  const unitProgress = getUnitProgress(unit.id);
+  const isVideoCompleted = unitProgress?.videoCompleted || videoCompleted;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">{unit.title}</h1>
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <h3 className="font-semibold text-blue-900 mb-2">Your Progress</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+            <div className="flex items-center">
+              <span className={`w-3 h-3 rounded-full mr-2 ${
+                isVideoCompleted ? 'bg-green-500' : 'bg-gray-300'
+              }`} />
+              <span>Video {isVideoCompleted ? 'Completed' : 'In Progress'}</span>
+            </div>
+            <div className="flex items-center">
+              <span className="text-blue-600 font-medium">
+                {unitProgress?.activitiesCompleted.length || 0}/{unit.activities.length} Activities
+              </span>
+            </div>
+            <div className="flex items-center">
+              <span className={`px-2 py-1 rounded text-xs font-medium ${
+                unitProgress?.completedAt ?
+                  'bg-green-100 text-green-800' :
+                  isVideoCompleted ?
+                    'bg-yellow-100 text-yellow-800' :
+                    'bg-gray-100 text-gray-600'
+              }`}>
+                {unitProgress?.completedAt ?
+                  'Unit Complete' :
+                  isVideoCompleted ?
+                    'In Progress' :
+                    'Not Started'
+                }
+              </span>
+            </div>
+          </div>
         </div>
-    );
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-4">Watch the Video</h2>
+        <VideoPlayer
+          url={unit.videoUrl}
+          unitId={unit.id}
+          onCompleted={() => setVideoCompleted(true)}
+        />
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Complete the Activities</h2>
+        <div className="space-y-6">
+          {unit.activities.map(activity => (
+            <ActivityEmbed
+              key={activity.id}
+              activity={activity}
+              unitId={unit.id}
+              isUnlocked={isVideoCompleted}
+            />
+          ))}
+        </div>
+      </div>
+
+      {unitProgress?.completedAt && (
+        <div className="mt-8 bg-green-50 border border-green-200 rounded-lg p-6 text-center">
+          <div className="text-4xl mb-2">🎉</div>
+          <h3 className="text-lg font-semibold text-green-900 mb-2">
+            Congratulations! You've completed this unit!
+          </h3>
+          <p className="text-green-700">
+            Completed on {unitProgress.completedAt.toLocaleDateString()}
+          </p>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default UnitPage;

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,27 +1,108 @@
-import * as React from "react";
+import React, { useRef, useEffect, useState } from 'react';
+import { useProgress } from '../contexts/ProgressContext';
 
-type Props = {
-    url: string;
-    onWatched: () => void;
-};
+interface VideoPlayerProps {
+  url: string;
+  unitId: number;
+  onCompleted: () => void;
+}
 
-const VideoPlayer: React.FC<Props> = ({ url, onWatched }) => {
-    // Simulate "watched" event after 1 second
-    React.useEffect(() => {
-        const timer = setTimeout(onWatched, 1000);
-        return () => clearTimeout(timer);
-    }, [onWatched]);
+const VideoPlayer: React.FC<VideoPlayerProps> = ({ url, unitId, onCompleted }) => {
+  const { markVideoCompleted, getUnitProgress } = useProgress();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [watchTime, setWatchTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [isCompleted, setIsCompleted] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-    return (
+  const unitProgress = getUnitProgress(unitId);
+
+  useEffect(() => {
+    if (unitProgress?.videoCompleted) {
+      setIsCompleted(true);
+      onCompleted();
+    }
+  }, [unitProgress, onCompleted]);
+
+  useEffect(() => {
+    const startTime = Date.now();
+    let lastTime = startTime;
+
+    intervalRef.current = setInterval(() => {
+      const now = Date.now();
+      const elapsed = (now - lastTime) / 1000;
+      lastTime = now;
+
+      setWatchTime(prev => {
+        const newWatchTime = prev + elapsed;
+
+        const estimatedDuration = duration || 300;
+        setDuration(estimatedDuration);
+
+        if (Math.floor(newWatchTime) % 10 === 0) {
+          markVideoCompleted(unitId, newWatchTime, estimatedDuration);
+        }
+
+        if (newWatchTime >= estimatedDuration * 0.9 && !isCompleted) {
+          setIsCompleted(true);
+          onCompleted();
+          markVideoCompleted(unitId, newWatchTime, estimatedDuration);
+        }
+
+        return newWatchTime;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+      if (watchTime > 0) {
+        markVideoCompleted(unitId, watchTime, duration);
+      }
+    };
+  }, [unitId, markVideoCompleted, onCompleted, duration, isCompleted, watchTime]);
+
+  const progress = duration > 0 ? Math.min((watchTime / duration) * 100, 100) : 0;
+
+  return (
+    <div className="video-player-container">
+      <div className="relative">
         <iframe
-            width="100%"
-            height="400"
-            src={url}
-            title="Unit Video"
-            allow="autoplay; encrypted-media"
-            allowFullScreen
+          ref={iframeRef}
+          width="100%"
+          height="400"
+          src={url}
+          title={`Unit ${unitId} Video`}
+          allow="autoplay; encrypted-media"
+          allowFullScreen
+          className="rounded-lg shadow-lg"
         />
-    );
+
+        <div className="mt-4 bg-gray-200 rounded-full h-3 overflow-hidden">
+          <div
+            className={`h-full transition-all duration-500 ${
+              isCompleted ? 'bg-green-500' : 'bg-blue-500'
+            }`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+
+        <div className="flex justify-between text-sm text-gray-600 mt-2">
+          <span>Progress: {progress.toFixed(1)}%</span>
+          <span>
+            {isCompleted ? (
+              <span className="text-green-600 font-semibold">✓ Completed</span>
+            ) : (
+              `${Math.floor(watchTime / 60)}:${(Math.floor(watchTime) % 60)
+                .toString()
+                .padStart(2, '0')} watched`
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default VideoPlayer;

--- a/src/contexts/ProgressContext.tsx
+++ b/src/contexts/ProgressContext.tsx
@@ -1,0 +1,157 @@
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { doc, setDoc, getDoc, collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import { useAuth } from './AuthContext';
+import type { UserProgress, UnitProgress } from '../types/progress';
+
+interface ProgressContextType {
+  userProgress: UserProgress[];
+  isProgressLoading: boolean;
+  markVideoCompleted: (unitId: number, watchTime: number, duration: number) => Promise<void>;
+  markActivityCompleted: (unitId: number, activityId: number) => Promise<void>;
+  getUnitProgress: (unitId: number) => UserProgress | undefined;
+  getProgressSummary: () => UnitProgress[];
+  refreshProgress: () => Promise<void>;
+}
+
+const ProgressContext = createContext<ProgressContextType | undefined>(undefined);
+
+export const useProgress = () => {
+  const context = useContext(ProgressContext);
+  if (context === undefined) {
+    throw new Error('useProgress must be used within a ProgressProvider');
+  }
+  return context;
+};
+
+export const ProgressProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { currentUser } = useAuth();
+  const [userProgress, setUserProgress] = useState<UserProgress[]>([]);
+  const [isProgressLoading, setIsProgressLoading] = useState(true);
+
+  const refreshProgress = useCallback(async () => {
+    if (!currentUser) {
+      setUserProgress([]);
+      setIsProgressLoading(false);
+      return;
+    }
+
+    try {
+      setIsProgressLoading(true);
+      const progressQuery = query(
+        collection(db, 'userProgress'),
+        where('userId', '==', currentUser.uid)
+      );
+
+      const querySnapshot = await getDocs(progressQuery);
+      const progress = querySnapshot.docs.map(doc => ({
+        ...doc.data(),
+        startedAt: doc.data().startedAt?.toDate() || new Date(),
+        completedAt: doc.data().completedAt?.toDate(),
+        lastAccessedAt: doc.data().lastAccessedAt?.toDate() || new Date(),
+      })) as UserProgress[];
+
+      setUserProgress(progress);
+    } catch (error) {
+      console.error('Error fetching user progress:', error);
+    } finally {
+      setIsProgressLoading(false);
+    }
+  }, [currentUser]);
+
+  useEffect(() => {
+    refreshProgress();
+  }, [currentUser, refreshProgress]);
+
+  const saveProgress = async (progress: Partial<UserProgress> & { unitId: number }) => {
+    if (!currentUser) return;
+
+    const progressId = `${currentUser.uid}_${progress.unitId}`;
+    const progressRef = doc(db, 'userProgress', progressId);
+
+    const existingProgress = await getDoc(progressRef);
+    const now = new Date();
+
+    const existingData = existingProgress.data() as Partial<UserProgress> | undefined;
+
+    const updatedProgress: UserProgress = {
+      userId: currentUser.uid,
+      videoCompleted: false,
+      videoWatchTime: 0,
+      videoDuration: 0,
+      activitiesCompleted: [],
+      startedAt: now,
+      ...existingData,
+      ...progress,
+      lastAccessedAt: now,
+      unitId: progress.unitId,
+    } as UserProgress;
+
+    // Mark as completed if video is done and all activities are completed
+    if (updatedProgress.videoCompleted && updatedProgress.activitiesCompleted.length > 0) {
+      updatedProgress.completedAt = now;
+    }
+
+    await setDoc(progressRef, updatedProgress);
+    await refreshProgress();
+  };
+
+  const markVideoCompleted = async (unitId: number, watchTime: number, duration: number) => {
+    const completionThreshold = 0.9; // 90% watched = completed
+    const isCompleted = (watchTime / duration) >= completionThreshold;
+
+    await saveProgress({
+      unitId,
+      videoCompleted: isCompleted,
+      videoWatchTime: Math.max(watchTime, userProgress.find(p => p.unitId === unitId)?.videoWatchTime || 0),
+      videoDuration: duration,
+    });
+  };
+
+  const markActivityCompleted = async (unitId: number, activityId: number) => {
+    const existingProgress = getUnitProgress(unitId);
+    const completedActivities = existingProgress?.activitiesCompleted || [];
+
+    if (!completedActivities.includes(activityId)) {
+      completedActivities.push(activityId);
+    }
+
+    await saveProgress({
+      unitId,
+      activitiesCompleted: completedActivities,
+    });
+  };
+
+  const getUnitProgress = (unitId: number): UserProgress | undefined => {
+    return userProgress.find(p => p.unitId === unitId);
+  };
+
+  const getProgressSummary = (): UnitProgress[] => {
+    return userProgress.map(progress => ({
+      unitId: progress.unitId,
+      title: `Unit ${progress.unitId}`,
+      status: progress.completedAt ? 'completed' :
+               progress.videoCompleted ? 'in-progress' : 'not-started',
+      videoProgress: progress.videoDuration > 0 ?
+                    Math.round((progress.videoWatchTime / progress.videoDuration) * 100) : 0,
+      activitiesCompleted: progress.activitiesCompleted.length,
+      totalActivities: 2,
+    }));
+  };
+
+  const value: ProgressContextType = {
+    userProgress,
+    isProgressLoading,
+    markVideoCompleted,
+    markActivityCompleted,
+    getUnitProgress,
+    getProgressSummary,
+    refreshProgress,
+  };
+
+  return (
+    <ProgressContext.Provider value={value}>
+      {children}
+    </ProgressContext.Provider>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,12 +10,14 @@ import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import Navbar from './components/layout/Navbar';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import { ProgressProvider } from './contexts/ProgressContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AuthProvider>
-      <BrowserRouter>
-        <div className="min-h-screen bg-gray-50">
+      <ProgressProvider>
+        <BrowserRouter>
+          <div className="min-h-screen bg-gray-50">
           <Navbar />
           <Routes>
             {/* Public Routes */}
@@ -44,8 +46,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             {/* Catch all route */}
             <Route path="*" element={<Navigate to="/" />} />
           </Routes>
-        </div>
-      </BrowserRouter>
+          </div>
+        </BrowserRouter>
+      </ProgressProvider>
     </AuthProvider>
   </React.StrictMode>
 );

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -1,0 +1,20 @@
+export interface UserProgress {
+  userId: string;
+  unitId: number;
+  videoCompleted: boolean;
+  videoWatchTime: number; // seconds watched
+  videoDuration: number; // total video duration
+  activitiesCompleted: number[];
+  startedAt: Date;
+  completedAt?: Date;
+  lastAccessedAt: Date;
+}
+
+export interface UnitProgress {
+  unitId: number;
+  title: string;
+  status: 'not-started' | 'in-progress' | 'completed';
+  videoProgress: number; // 0-100%
+  activitiesCompleted: number;
+  totalActivities: number;
+}


### PR DESCRIPTION
## Summary
- define progress interfaces in `src/types`
- introduce `ProgressContext` for storing user progress in Firestore
- enhance `VideoPlayer` to track watch time and completion
- update `ActivityEmbed` to mark activities complete
- update `UnitPage` to display progress status
- wrap app with `ProgressProvider` in `main.tsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879a1a60f648325af6eff89ec8b400c