### PR TITLE
Fix AdminPage state type

### DIFF
--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -12,7 +12,7 @@ import type { Unit, Lesson, Activity } from '../data/sampleUnits';
 
 const AdminPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'units' | 'lessons'>('units');
-  const [existingUnits, setExistingUnits] = useState<Unit[]>([]);
+  const [existingUnits, setExistingUnits] = useState<(Unit & { docId: string })[]>([]);
 
   // Unit creation state
   const [unitTitle, setUnitTitle] = useState('');
@@ -112,9 +112,7 @@ const AdminPage: React.FC = () => {
       return;
     }
 
-    const selectedUnit = (existingUnits as (Unit & { docId: string })[]).find(
-      u => u.docId === selectedUnitId
-    );
+    const selectedUnit = existingUnits.find(u => u.docId === selectedUnitId);
     if (!selectedUnit) {
       alert('Selected unit not found');
       return;


### PR DESCRIPTION
## Summary
- include Firestore `docId` in `existingUnits` state
- simplify lesson selection logic using the typed state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c0e4fba10832595324ddae48c50ac