### PR TITLE
Implement role-based signup and admin controls

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useUnits } from '../hooks/useUnits';
 import { useProgress } from '../contexts/ProgressContext';
+import { useAuth } from '../contexts/AuthContext';
 
 const Dashboard: React.FC = () => {
   const { units, loading, error } = useUnits();
   const { getUnitProgress } = useProgress();
+  const { isTeacher } = useAuth();
 
   if (loading) {
     return (
@@ -100,12 +102,14 @@ const Dashboard: React.FC = () => {
       <div className="bg-white rounded-lg shadow-md p-6 mb-8">
         <h2 className="text-xl font-semibold mb-4">Quick Actions</h2>
         <div className="flex flex-wrap gap-4">
-          <Link
-            to="/admin"
-            className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-lg font-medium transition-colors flex items-center"
-          >
-            ⚙️ Admin Panel
-          </Link>
+          {isTeacher && (
+            <Link
+              to="/admin"
+              className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-lg font-medium transition-colors flex items-center"
+            >
+              ⚙️ Admin Panel
+            </Link>
+          )}
         </div>
       </div>
 

--- a/src/components/UnitPage.tsx
+++ b/src/components/UnitPage.tsx
@@ -136,7 +136,11 @@ const UnitPage: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {unit.lessons
               .sort((a, b) => a.order - b.order)
-              .map((lesson) => {
+              .map((lesson, idx, arr) => {
+                const prevCompleted =
+                  idx === 0 ||
+                  unitProgress?.lessonsProgress[arr[idx - 1].id]?.completedAt;
+                const isLocked = !prevCompleted;
                 const lessonProgress = unitProgress?.lessonsProgress[lesson.id];
                 const isCompleted = lessonProgress?.completedAt;
                 const isStarted = lessonProgress?.videoCompleted || (lessonProgress?.activitiesCompleted.length || 0) > 0;
@@ -163,12 +167,16 @@ const UnitPage: React.FC = () => {
                       </div>
                       
                       {/* Completion Badge */}
-                      {isCompleted && (
-                        <div className="absolute top-2 right-2 bg-green-500 text-white rounded-full p-2">
-                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                          </svg>
-                        </div>
+                      {isLocked ? (
+                        <div className="absolute top-2 right-2 bg-gray-400 text-white rounded-full p-2">🔒</div>
+                      ) : (
+                        isCompleted && (
+                          <div className="absolute top-2 right-2 bg-green-500 text-white rounded-full p-2">
+                            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                              <path fillRule="evenodd" d="M16.707 5.293a1 1 0 011.414 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                            </svg>
+                          </div>
+                        )
                       )}
                     </div>
 
@@ -214,29 +222,47 @@ const UnitPage: React.FC = () => {
 
                         {/* Status */}
                         <div className="text-center">
-                          <span className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${
-                            isCompleted ? 'bg-green-100 text-green-800' : 
-                            isStarted ? 'bg-yellow-100 text-yellow-800' : 
-                            'bg-gray-100 text-gray-600'
-                          }`}>
-                            {isCompleted ? '🎉 Complete' : isStarted ? '⏳ In Progress' : '📚 Not Started'}
+                          <span
+                            className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${
+                              isLocked
+                                ? 'bg-gray-100 text-gray-600'
+                                : isCompleted
+                                  ? 'bg-green-100 text-green-800'
+                                  : isStarted
+                                    ? 'bg-yellow-100 text-yellow-800'
+                                    : 'bg-gray-100 text-gray-600'
+                            }`}
+                          >
+                            {isLocked
+                              ? '🔒 Locked'
+                              : isCompleted
+                                ? '🎉 Complete'
+                                : isStarted
+                                  ? '⏳ In Progress'
+                                  : '📚 Not Started'}
                           </span>
                         </div>
                       </div>
 
                       {/* Action Button */}
-                      <Link
-                        to={`/unit/${unit.id}/lesson/${lesson.id}`}
-                        className={`block w-full text-center py-3 px-4 rounded-lg font-medium transition-colors ${
-                          isCompleted ? 
-                            'bg-green-600 hover:bg-green-700 text-white' : 
-                            isStarted ? 
-                              'bg-blue-600 hover:bg-blue-700 text-white' : 
-                              'bg-gray-800 hover:bg-gray-900 text-white'
-                        }`}
-                      >
-                        {isCompleted ? 'Review Lesson' : isStarted ? 'Continue Lesson' : 'Start Lesson'}
-                      </Link>
+                      {isLocked ? (
+                        <div className="block w-full text-center py-3 px-4 rounded-lg font-medium bg-gray-300 text-gray-500 cursor-not-allowed">
+                          Locked
+                        </div>
+                      ) : (
+                        <Link
+                          to={`/unit/${unit.id}/lesson/${lesson.id}`}
+                          className={`block w-full text-center py-3 px-4 rounded-lg font-medium transition-colors ${
+                            isCompleted
+                              ? 'bg-green-600 hover:bg-green-700 text-white'
+                              : isStarted
+                                ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                                : 'bg-gray-800 hover:bg-gray-900 text-white'
+                          }`}
+                        >
+                          {isCompleted ? 'Review Lesson' : isStarted ? 'Continue Lesson' : 'Start Lesson'}
+                        </Link>
+                      )}
 
                       {/* Completion Date */}
                       {isCompleted && lessonProgress?.completedAt && (

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import ReactPlayer from 'react-player';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Player = ReactPlayer as unknown as React.ComponentType<any>;
 import { useProgress } from '../contexts/ProgressContext';
 
@@ -19,6 +20,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onCompleted
 }) => {
   const { markLessonVideoCompleted, getUnitProgress } = useProgress();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const playerRef = useRef<any>(null);
   const [duration, setDuration] = useState(0);
   const [playedSeconds, setPlayedSeconds] = useState(0);
@@ -63,6 +65,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
   }, [playedSeconds, isCompleted]);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleProgress = (state: any) => {
     setPlayedSeconds(state.playedSeconds);
     if (duration > 0) {
@@ -111,13 +114,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         src={url}
         controls
         onProgress={handleProgress}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         onDurationChange={handleDuration}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         config={
           (captionsUrl
             ? { file: { tracks: [{ kind: 'subtitles', src: captionsUrl, srcLang: 'en', default: true }] } }
-            : undefined) as any
+            : undefined) as unknown
         }
         width="100%"
         height="400px"

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -4,10 +4,11 @@ import { useAuth } from '../../contexts/AuthContext';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  requiresAdmin?: boolean;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  const { currentUser, loading } = useAuth();
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiresAdmin }) => {
+  const { currentUser, loading, role } = useAuth();
 
   if (loading) {
     return (
@@ -17,5 +18,13 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     );
   }
 
-  return currentUser ? <>{children}</> : <Navigate to="/login" />;
+  if (!currentUser) {
+    return <Navigate to="/login" />;
+  }
+
+  if (requiresAdmin && role !== 'teacher') {
+    return <Navigate to="/" />;
+  }
+
+  return <>{children}</>;
 };

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -8,6 +8,7 @@ const Signup: React.FC = () => {
     email: '',
     password: '',
     confirmPassword: '',
+    role: 'student',
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -22,7 +23,13 @@ const Signup: React.FC = () => {
   };
 
   const validateForm = () => {
-    if (!formData.name || !formData.email || !formData.password || !formData.confirmPassword) {
+    if (
+      !formData.name ||
+      !formData.email ||
+      !formData.password ||
+      !formData.confirmPassword ||
+      !formData.role
+    ) {
       setError('Please fill in all fields');
       return false;
     }
@@ -48,7 +55,12 @@ const Signup: React.FC = () => {
     try {
       setError('');
       setLoading(true);
-      await signup(formData.email, formData.password, formData.name);
+      await signup(
+        formData.email,
+        formData.password,
+        formData.name,
+        formData.role
+      );
       navigate('/');
     } catch (error: unknown) {
       let errorMessage = 'Failed to create account';
@@ -154,6 +166,34 @@ const Signup: React.FC = () => {
                 className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
                 placeholder="Confirm your password"
               />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+              <div className="flex space-x-4">
+                <label className="flex items-center space-x-1">
+                  <input
+                    type="radio"
+                    name="role"
+                    value="student"
+                    checked={formData.role === 'student'}
+                    onChange={handleChange}
+                    className="form-radio"
+                  />
+                  <span className="text-sm">Student</span>
+                </label>
+                <label className="flex items-center space-x-1">
+                  <input
+                    type="radio"
+                    name="role"
+                    value="teacher"
+                    checked={formData.role === 'teacher'}
+                    onChange={handleChange}
+                    className="form-radio"
+                  />
+                  <span className="text-sm">Teacher</span>
+                </label>
+              </div>
             </div>
           </div>
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 
 const Navbar: React.FC = () => {
-  const { currentUser, logout } = useAuth();
+  const { currentUser, logout, isTeacher } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -31,12 +31,14 @@ const Navbar: React.FC = () => {
                 <span className="text-gray-700">
                   Hi, {currentUser.displayName || currentUser.email}
                 </span>
-                <Link
-                  to="/admin"
-                  className="text-gray-700 hover:text-blue-600 px-3 py-2"
-                >
-                  Admin
-                </Link>
+                {isTeacher && (
+                  <Link
+                    to="/admin"
+                    className="text-gray-700 hover:text-blue-600 px-3 py-2"
+                  >
+                    Admin
+                  </Link>
+                )}
                 <button
                   onClick={handleLogout}
                   className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -64,7 +64,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             <Route
               path="/admin"
               element={
-                <ProtectedRoute>
+                <ProtectedRoute requiresAdmin>
                   <AdminPage />
                 </ProtectedRoute>
               }


### PR DESCRIPTION
## Summary
- extend signup with teacher/student roles
- store user role in Firestore and expose role in auth context
- restrict admin routes with `ProtectedRoute` and show admin links only for teachers
- lock lessons until previous lesson completed
- add student progress tab in admin panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882d39987d08325ad8c28d6e5049237